### PR TITLE
fix headers1 tests

### DIFF
--- a/tests/homePage/headerPart1.spec.js
+++ b/tests/homePage/headerPart1.spec.js
@@ -1,37 +1,37 @@
 //@ts-check
-const { test, expect } = require("@playwright/test");
+const { test, expect } = require('@playwright/test');
 
-test("Check redirect to what-is-new page", async ({ page }) => {
-  await page.goto("https://magento.softwaretestingboard.com/");
-  await page.getByRole("link", { name: "What's New" }).click();
+test('Check redirect to what-is-new page', async ({ page }) => {
+  await page.goto('https://magento.softwaretestingboard.com/');
+  await page.locator('#ui-id-3').click();
   await expect(page).toHaveURL(/what-is-new/);
 });
 
-test("Check redirect to women page", async ({ page }) => {
-  await page.goto("https://magento.softwaretestingboard.com/");
-  await page.getByRole("link", { name: "Women", exact: true }).click();
+test('Check redirect to women page', async ({ page }) => {
+  await page.goto('https://magento.softwaretestingboard.com/');
+  await page.locator('#ui-id-4').click();
   await expect(page).toHaveURL(/women/);
 });
-test("Check redirect to men page", async ({ page }) => {
-  await page.goto("https://magento.softwaretestingboard.com/");
-  await page.getByRole("link", { name: "Men", exact: true }).click();
+test('Check redirect to men page', async ({ page }) => {
+  await page.goto('https://magento.softwaretestingboard.com/');
+  await page.locator('#ui-id-5').click();
   await expect(page).toHaveURL(/men/);
 });
 
-test("Check redirect to gear page", async ({ page }) => {
-  await page.goto("https://magento.softwaretestingboard.com/");
-  await page.getByRole("link", { name: "Gear", exact: true }).click();
+test('Check redirect to gear page', async ({ page }) => {
+  await page.goto('https://magento.softwaretestingboard.com/');
+  await page.locator('#ui-id-6').click();
   await expect(page).toHaveURL(/gear/);
 });
 
-test("Check redirect to training page", async ({ page }) => {
-  await page.goto("https://magento.softwaretestingboard.com/");
-  await page.getByRole("link", { name: "Training", exact: true }).click();
+test('Check redirect to training page', async ({ page }) => {
+  await page.goto('https://magento.softwaretestingboard.com/');
+  await page.locator('#ui-id-7').click();
   await expect(page).toHaveURL(/training/);
 });
 
-test("Check redirect to sale page", async ({ page }) => {
-  await page.goto("https://magento.softwaretestingboard.com/");
-  await page.getByRole("link", { name: "Sale", exact: true }).click();
+test('Check redirect to sale page', async ({ page }) => {
+  await page.goto('https://magento.softwaretestingboard.com/');
+  await page.locator('#ui-id-8').click();
   await expect(page).toHaveURL(/sale/);
 });


### PR DESCRIPTION
fix headers1 tests, changes locator from getBy.. to page.locator
![image](https://github.com/adrianmaciuc/break-it-playwright-javascript-project/assets/48152758/a618c207-cac9-4ed4-be9e-bb7be3918a74)
